### PR TITLE
More robust pubdate handling, fixes #1, adds a method for EnclosureURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ First, install libxml and its development headers by way of your package manager
 
 Ubuntu:
 ```bash
-sudo apt-get install libxml2-dev libxml2
+sudo apt-get install libxml2-dev libxml2 pkg-config
 ```
 
 Fedora/CentOS/RHEL:

--- a/rss.go
+++ b/rss.go
@@ -78,7 +78,7 @@ func Decode(data []byte) (*RSS, error) {
 	getChannel(&xmlrssObj, rootNode)
 	getChannelElem(&rssObj, xmlrssObj.channel)
 	getItems(&xmlChanObj, xmlrssObj.channel)
-    rssObj.channel.items = make([]Item,len(xmlChanObj.items))
+	rssObj.channel.items = make([]Item, len(xmlChanObj.items))
 	for itemID := 0; itemID < len(xmlChanObj.items); itemID++ {
 		getItemMeta(&rssObj, itemID, xmlChanObj.items[itemID])
 	}
@@ -267,6 +267,11 @@ func (i Item) Date() (*time.Time, error) {
 //Whether or not the item has a media enclosure.
 func (i Item) HasEnclosure() bool {
 	return i.hasEnclosure
+}
+
+//The media enclosure url.
+func (i Item) GetEnclosureURL() string {
+	return i.enclosure.url
 }
 
 //Returns the item . If the item title is not populated, you'll get an empty string and an error.

--- a/rss.go
+++ b/rss.go
@@ -171,8 +171,48 @@ func getItemMeta(r *RSS, itemID int, i xml.Node) {
 			case "link":
 				r.channel.items[itemID].link = tagContent
 			case "pubDate":
-				if parsedDate, perr := time.Parse("Mon, 02 Feb 2006 15:04:05 -0700", tagContent); perr == nil {
-					r.channel.items[itemID].date = &parsedDate
+				layouts := []string{
+					"2006-01-02 15:04:05 -0700 MST",
+					"2006-01-02 15:04:05 -0700",
+					"2006-01-02 15:04:05",
+					"2006/01/02 15:04:05 -0700 MST",
+					"2006/01/02 15:04:05 -0700",
+					"2006/01/02 15:04:05",
+					"2006-01-02 -0700 MST",
+					"2006-01-02 -0700",
+					"2006-01-02",
+					"2006/01/02 -0700 MST",
+					"2006/01/02 -0700",
+					"2006/01/02",
+					"2006-01-02 15:04:05 -0700 -0700",
+					"2006/01/02 15:04:05 -0700 -0700",
+					"2006-01-02 -0700 -0700",
+					"2006/01/02 -0700 -0700",
+					"Mon, 2 Jan 2006 15:04:05 MST",
+					time.ANSIC,
+					time.UnixDate,
+					time.RubyDate,
+					time.RFC822,
+					time.RFC822Z,
+					time.RFC850,
+					time.RFC1123,
+					time.RFC1123Z,
+					time.RFC3339,
+					time.RFC3339Nano,
+					time.Kitchen,
+					time.Stamp,
+					time.StampMilli,
+					time.StampMicro,
+					time.StampNano,
+				}
+				var parsedDate time.Time
+				var err error
+				for _, layout := range layouts {
+					parsedDate, err = time.Parse(layout, tagContent)
+					if err == nil {
+						r.channel.items[itemID].date = &parsedDate
+						break
+					}
 				}
 			case "description":
 				r.channel.items[itemID].description = tagContent
@@ -270,7 +310,7 @@ func (i Item) HasEnclosure() bool {
 }
 
 //The media enclosure url.
-func (i Item) GetEnclosureURL() string {
+func (i Item) EnclosureURL() string {
 	return i.enclosure.url
 }
 


### PR DESCRIPTION
I've been using this package on a personal project and found that it lacks a bit of features I needed and figured out that maybe you'd want to include them back. 
- I've fixed #1 treating both cases where itunes:duration is a both a number of seconds or a hh:mm string
- added a necessary package for usage on ubuntu (pkg-config)
- added a more diverse pubdate handling with a lot more date formats
- added a method for getting the item enclosure url

Let me know if they're alright for you.
